### PR TITLE
Return JSON for empty session lists

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -381,6 +381,11 @@ describe('CLI daemon control', () => {
     const sessions = await runCli(['sessions'])
     expect(sessions.exitCode).toBe(0)
     expect(sessions.stdout).toBe('No active sessions')
+
+    const jsonSessions = await runCli(['sessions', '--json'])
+    expect(jsonSessions.exitCode).toBe(0)
+    expect(jsonSessions.stdout).toBe('[]')
+    expect(JSON.parse(jsonSessions.stdout)).toEqual([])
   }, 10000)
 })
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1089,7 +1089,7 @@ function createCliWithActions(
     .action((options: { json?: boolean }) => {
       const entries = Array.from(sessions.entries())
       if (entries.length === 0) {
-        ctx.stdout = 'No active sessions'
+        ctx.stdout = options.json ? '[]' : 'No active sessions'
         return
       }
       if (options.json) {


### PR DESCRIPTION
## Summary

- Return `[]` for `tuistory sessions --json` when there are no active sessions
- Preserve the existing human-readable `No active sessions` output without `--json`
- Add a regression assertion that the empty JSON output parses correctly

## Validation

```bash
# Fresh `bun install` is currently blocked by the existing ghostty-opentui workspace dependency issue.
# For validation only, I temporarily pinned ghostty-opentui to the latest published version, built, and ran:
npx -y bun run build
npx -y bun test src/cli.test.ts -t 'daemon-stop stops the relay and clears active sessions'
```

Result:

```text
1 pass
0 fail
```
