### PR TITLE
Update kill-port-process

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ghostty-opentui": "workspace:^",
     "goke": "^6.9.0",
     "hono": "^4.11.7",
-    "kill-port-process": "^3.2.1",
+    "kill-port-process": "^4.0.2",
     "picocolors": "^1.1.1",
     "react": "^19",
     "std-env": "^4.1.0",


### PR DESCRIPTION
## Summary

Bumps `kill-port-process` from `^3.2.1` to `^4.0.2`.

This removes the old vulnerable transitive chain through `pid-from-port` / `execa` / `cross-spawn` while keeping the same `killPortProcess` export used by tuistory.

## Validation

- `npx -y bun run build` passed with a temporary local workaround for the existing `ghostty-opentui` workspace dependency issue.
