### PR TITLE
feat: make terminal idle delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ tuistory -s x wait "Tests:" --timeout 60000
 tuistory read -s x
 ```
 
-**Use `wait-idle` when you don't know what to wait for.** It waits until the terminal stops receiving data (~60ms of silence):
+**Use `wait-idle` when you don't know what to wait for.** It waits until the terminal stops receiving data (~200ms of silence by default):
 
 ```bash
 tuistory -- npm test
@@ -402,8 +402,16 @@ const session = await launchTerminal({
   rows: 36,
   cwd: '/path/to/dir',
   env: { MY_VAR: 'value' },
+  idleDelayMs: 200,
 })
 ```
+
+`idleDelayMs` controls how long the PTY must stop producing output before the
+session is considered idle. It defaults to 200ms so multi-write TUI renders are
+captured as complete frames. Use a shorter delay only when the application
+renders atomically or your test follows actions with a stronger readiness
+predicate. The default `waitIdle()` timeout grows with longer configured delays;
+an explicit `waitIdle({ timeout })` still takes precedence.
 
 ### `session.type(text)`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -454,7 +454,7 @@ function createCliWithActions(
 
       Returns the full text content of the terminal buffer.
       By default, waits for the terminal to become idle before
-      capturing (no new data for ~60ms).
+      capturing (no new data for ~200ms).
 
       Use \`--trim\` to strip trailing whitespace and empty lines
       for cleaner output. Use \`--json\` to get structured output
@@ -1036,7 +1036,7 @@ function createCliWithActions(
     .command('wait-idle', dedent`
       Wait for the terminal to stop receiving data (become idle).
 
-      Waits until no new data has been received for ~60ms,
+      Waits until no new data has been received for ~200ms,
       indicating the application has finished rendering.
 
       Useful between rapid actions to ensure the terminal has

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -30,6 +30,84 @@ test('echo command', async () => {
   session.close()
 }, 10000)
 
+test('supports a configurable idle delay', async () => {
+  const session = await launchTerminal({
+    command: process.execPath,
+    args: [
+      '-e',
+      `process.stdout.write('first');
+       setTimeout(() => process.stdout.write('second'), 120);
+       setTimeout(() => process.exit(0), 500);`,
+    ],
+    cols: 40,
+    rows: 10,
+    idleDelayMs: 20,
+    waitForData: false,
+  })
+
+  try {
+    await session.waitForData({ timeout: 1000 })
+    await session.waitIdle({ timeout: 500 })
+
+    const firstIdleFrame = await session.text({ immediate: true })
+    expect(firstIdleFrame).toContain('first')
+    expect(firstIdleFrame).not.toContain('second')
+
+    await session.waitForText('second', { timeout: 1000 })
+  } finally {
+    session.close()
+  }
+}, 10000)
+
+test('uses a 200ms idle delay by default', async () => {
+  const session = await launchTerminal({
+    command: process.execPath,
+    args: [
+      '-e',
+      `process.stdout.write('first');
+       setTimeout(() => process.stdout.write('second'), 120);
+       setTimeout(() => process.exit(0), 500);`,
+    ],
+    cols: 40,
+    rows: 10,
+    waitForData: false,
+  })
+
+  try {
+    await session.waitForData({ timeout: 1000 })
+    await session.waitIdle()
+
+    expect(await session.text({ immediate: true })).toContain('second')
+  } finally {
+    session.close()
+  }
+}, 10000)
+
+test('extends the default wait timeout for longer idle delays', async () => {
+  const session = await launchTerminal({
+    command: process.execPath,
+    args: [
+      '-e',
+      `process.stdout.write('first');
+       setTimeout(() => process.stdout.write('second'), 550);
+       setTimeout(() => process.exit(0), 1500);`,
+    ],
+    cols: 40,
+    rows: 10,
+    idleDelayMs: 600,
+    waitForData: false,
+  })
+
+  try {
+    await session.waitForData({ timeout: 1000 })
+    await session.waitIdle()
+
+    expect(await session.text({ immediate: true })).toContain('second')
+  } finally {
+    session.close()
+  }
+}, 10000)
+
 test('cat interactive', async () => {
   const session = await launchTerminal({
     command: 'cat',

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,6 +14,8 @@ export interface LaunchOptions {
   showCursor?: boolean
   /** Human-readable command string for display (e.g. "pnpm dev"). Falls back to command + args. */
   label?: string
+  /** Milliseconds without PTY output before the session is considered idle. Default: 200. */
+  idleDelayMs?: number
 }
 
 function sanitizeTermcastDbSuffix(suffix: string): string {
@@ -186,6 +188,7 @@ export class Session {
   private dataResolvers: Array<() => void> = []
   private closed = false
   private showCursor: boolean
+  private idleDelayMs: number
   // Original env options passed at launch (not the full process.env merge).
   // Stored so restart can faithfully recreate the session.
   private sessionEnv: Record<string, string | undefined>
@@ -213,6 +216,7 @@ export class Session {
     this.cols = options.cols ?? 120
     this.rows = options.rows ?? 36
     this.showCursor = options.showCursor ?? false
+    this.idleDelayMs = options.idleDelayMs ?? 200
     this.sessionCwd = options.cwd ?? process.cwd()
     this.sessionCommand = options.label ?? [options.command, ...(options.args ?? [])].join(' ')
     this.sessionEnv = options.env ?? {}
@@ -281,7 +285,7 @@ export class Session {
         resolvers.forEach((fn) => {
           fn()
         })
-      }, 200) // Wait 200ms after last data for content to stabilize
+      }, this.idleDelayMs)
     })
 
     // When the PTY child process exits, mark session as dead and resolve all
@@ -470,7 +474,7 @@ export class Session {
   }
 
   async waitIdle(options?: { timeout?: number }): Promise<void> {
-    const timeout = options?.timeout ?? 500
+    const timeout = options?.timeout ?? Math.max(500, this.idleDelayMs * 2)
     return new Promise<void>((resolve) => {
       if (!this.idleTimer) {
         setTimeout(resolve, Math.min(timeout, 20))


### PR DESCRIPTION
## What happened in Hunk

This came out of an attempt to upgrade [Hunk](https://github.com/modem-dev/hunk), a terminal diff viewer, from Tuistory 0.0.16 to 0.10.1.

The upgrade was source-compatible and all of Hunk's PTY tests still passed, but the integration suite became much slower. Hunk has 100 real-PTY tests. Across three baseline runs on Tuistory 0.0.16, the suite had a median runtime of 154.22 seconds. On 0.10.1, the same suite took 253.96 seconds — almost 100 seconds longer, or about a 65% regression.

I traced that difference to the idle debounce changing from 60ms to 200ms. The reason for that change makes sense: some TUIs render one logical frame through several writes, and a 60ms gap can make `waitIdle()` return while the frame is still incomplete. A conservative 200ms default is safer for a general-purpose terminal testing library.

Hunk happens to pay that delay hundreds of times. Methods such as `press()`, `type()`, and scrolling wait for the session to become idle, and Hunk will often follow those calls with a stronger readiness check against the actual screen content. In those cases the generic 200ms settling window is additional waiting rather than the thing that establishes correctness.

As a control, I changed only the debounce in the installed 0.10.1 package back to 60ms. The full Hunk PTY suite then completed in 152.81 seconds, with all 100 tests and 380 assertions passing. That confirmed the regression was caused by the accumulated debounce rather than package startup, terminal parsing, or another dependency change.

## What this PR changes

This PR makes the idle settle window configurable through `LaunchOptions`:

```ts
const session = await launchTerminal({
  command: 'my-tui',
  idleDelayMs: 60,
})
```

The default remains **200ms**. Existing callers get exactly the current fidelity-first behavior unless they explicitly choose another value.

This gives applications a supported way to select a shorter delay when they know their renderer's behavior or when their tests already wait for an observable condition after sending input. It avoids consumers having to patch Tuistory internally or stay on an older release.

While adding the option, I also adjusted the implicit `waitIdle()` timeout. Previously that timeout was fixed at 500ms, so a configured idle delay above 500ms could never be observed in full. The default timeout now remains at least 500ms and grows to twice the configured idle delay. An explicitly supplied `waitIdle({ timeout })` still takes precedence.

The README now explains the tradeoff and recommends keeping the conservative default unless the caller has a stronger readiness predicate. I also corrected two older CLI help descriptions that still said the default idle window was approximately 60ms.

## Compatibility

- The `idleDelayMs` option is optional.
- The default remains 200ms.
- Existing `waitIdle({ timeout })` calls keep their explicit timeout behavior.
- No CLI option or daemon behavior changes are required; the new setting is available to programmatic library users through the existing `LaunchOptions` path.

## Testing

I added coverage for three cases:

1. a short custom delay can resolve before a later output burst;
2. omitting the option preserves the 200ms default and waits across that burst;
3. delays above 500ms extend the implicit wait ceiling instead of being cut off early.

Validation completed locally:

- `bun run typecheck`
- `bun test` — 80 passed, 2 skipped
- `bun run test:node` — 19 passed, 2 skipped
- the three new idle-delay cases repeated ten times under Bun — 30/30 passed
- the new cases also passed under Node/Vitest

*This PR description was generated by Pi using gpt-5.6-sol*
